### PR TITLE
asar compatibility

### DIFF
--- a/Code/bank_80.asm
+++ b/Code/bank_80.asm
@@ -964,7 +964,7 @@ Hud:
    !phb
 	STZ !W_Hud_update_flags
 	; --- the address mirrors with their update flag changes go here ---
-	incsrc Code/data/hud/hud_mirrors.asm
+	incsrc data/hud/hud_mirrors.asm
 	; ------------------------------------------------------------------
 
 	LDA !W_Hud_update_flags : AND !W_Hud_expect_flags : BEQ .end
@@ -1010,7 +1010,7 @@ Hud_style:
 .types : dw .default
 
 ; here you would put the hud referenced in 'types'
-.default : dw .default_tiles : incsrc Code/data/hud/default.asm
+.default : dw .default_tiles : incsrc data/hud/default.asm
 
 ; and this is where the tile data table referenced in the individual hud table goes
 .default_tiles
@@ -1020,15 +1020,15 @@ Hud_style:
 
 ; ::: the data for all the modules goes here :::
 Hud_module:
-incsrc Code/data/hud/module_data.asm
+incsrc data/hud/module_data.asm
 
 ; ::: this is where all the tilemaps are stored :::
 Hud_tilemaps:
-incsrc Code/data/hud/hud_tilemaps.asm
+incsrc data/hud/hud_tilemaps.asm
 
 ; ::: all methods used by the modules go here :::
 Hud_method:
-incsrc Code/data/hud/hud_methods.asm
+incsrc data/hud/hud_methods.asm
 
 ; ::: methods for checking conditions go here :::
 Hud_condition:

--- a/Code/bank_81.asm
+++ b/Code/bank_81.asm
@@ -16,7 +16,7 @@ org $818085 : JMP File_load_game
 ; but not before the hexagonal map is shown, because that uses a different set of data and sprites
 org $81ADB7 : ADC #$000E						;this is for going backwards from the square map, so that it will reload the file select sprites
 org $81AC6D : JSR Start_game_loop_to_square_map	;this is going forward to the square map, so that it loads the map sprites
-org $81B14B : incsrc Code/data/subscreens/new_game_square_map.asm ;this is the tilemap under the square map ('map scroll', 'start', 'cancel')
+org $81B14B : incsrc data/subscreens/new_game_square_map.asm ;this is the tilemap under the square map ('map scroll', 'start', 'cancel')
 org $819E3E
 	REP #$30
 	PHB : PHK

--- a/Code/bank_82.asm
+++ b/Code/bank_82.asm
@@ -1,7 +1,7 @@
 lorom
 
 ; because the arrangement of sprite gfx in vram during the pause screen has changed, the sprites needed to be adjusted
-incsrc Code/data/subscreens/pause_sprites_vanilla.asm
+incsrc data/subscreens/pause_sprites_vanilla.asm
 
 ; --- Quote58 ---
 ; this is misc stuff that needed to be adjusted for various reasons for BE
@@ -9,7 +9,7 @@ org $82F088 : dw $F08E, Moonwalk_option, $F0B2
 org $828FE4 : STA !W_CGRAM_Backup,x		;in vanilla, this is stored to and loaded from 7E:3300, which is also used by message boxes
 org $82A2EE : LDA !W_CGRAM_Backup,x		;this was fine, because message boxes couldn't be used on the subscreen. However, now that they can, this ram has been changed to 7F
 org $82965F								;because of moving gfx around, the tilemaps for the area names need to be rewritten
-table Code/data/subscreens/text_subscreen.txt
+table data/subscreens/text_subscreen.txt
 Map_names: : dw .crateria, .brinstar, .norfair, .w_ship, .maridia, .tourian, .ceres, .tourian
 .crateria : dw "__crateria__"			;it's also now convenient to change them though
 .brinstar : dw "__brinstar__"
@@ -392,7 +392,7 @@ Subscreen:
 	JSR ($0000,x)
 	RTS
 
-.screen_type : dw .map_screen, .equip_screen, .options_screen,
+.screen_type : dw .map_screen, .equip_screen, .options_screen
 
 .map_screen     : dw .map_load, .map_in, .map, .map_out
 .equip_screen   : dw .equip_load, .equip_in, .equip, .equip_out

--- a/Code/bank_83.asm
+++ b/Code/bank_83.asm
@@ -8,37 +8,37 @@ org $83AD66
 ; all the tilemaps for the individual subscreens goes here
 Map_init_tilemap:
 .buttons
-	incsrc Code/data/subscreens/map_screen/map_buttons.asm
+	incsrc data/subscreens/map_screen/map_buttons.asm
 
 Equip_init_tilemap:
-	incsrc Code/data/subscreens/equip_screen/equip_tilemap.asm
+	incsrc data/subscreens/equip_screen/equip_tilemap.asm
 .buttons
-	incsrc Code/data/subscreens/equip_screen/equip_buttons.asm
+	incsrc data/subscreens/equip_screen/equip_buttons.asm
 
 Options_init_tilemap:
-	incsrc Code/data/subscreens/options_screen/options_tilemap.asm
+	incsrc data/subscreens/options_screen/options_tilemap.asm
 .buttons
-	incsrc Code/data/subscreens/options_screen/options_buttons.asm
+	incsrc data/subscreens/options_screen/options_buttons.asm
 
 Button_config_init_tilemap:
-	incsrc Code/data/subscreens/button_config/button_config_tilemap.asm
+	incsrc data/subscreens/button_config/button_config_tilemap.asm
 
 Unpausing_tilemap:
 .buttons
-	incsrc Code/data/subscreens/unpausing_buttons.asm
+	incsrc data/subscreens/unpausing_buttons.asm
 
 ; the equipment screen samus model tilemaps and modifiers are stored here as well
 Equip_samus_tilemaps:
-	incsrc Code/data/subscreens/equip_screen/equip_samus.asm
+	incsrc data/subscreens/equip_screen/equip_samus.asm
 
 Equip_samus_modifier:
-	incsrc Code/data/subscreens/equip_screen/equip_samus_modifiers.asm
+	incsrc data/subscreens/equip_screen/equip_samus_modifiers.asm
 
 ; these credit sheets are each $500 bytes, so they take up space really quickly being uncompressed
 Credit_sheet_data:
-.special_thanks :      incsrc Code/data/credit_sheets/credit_sheet_ST.asm
-.programming_credits : incsrc Code/data/credit_sheets/credit_sheet_PC.asm
-.tester_credits :      incsrc Code/data/credit_sheets/credit_sheet_TC.asm
+.special_thanks :      incsrc data/credit_sheets/credit_sheet_ST.asm
+.programming_credits : incsrc data/credit_sheets/credit_sheet_PC.asm
+.tester_credits :      incsrc data/credit_sheets/credit_sheet_TC.asm
 
 ; these tilemaps are to avoid having 4 of the same tile in misc sprite vram at all times
 ; but they do take up a lot of space, so I'm leaving them here
@@ -49,6 +49,6 @@ Frame_1_gate:   dw $0004 : %oam_h_square(00,00,be,2a)
 
 ; there are a ton of extra sprites used on the pause screen, so the tilemaps are stored here
 Pause_spritemaps_extra:
-incsrc Code/data/subscreens/pause_sprites_extra.asm
+incsrc data/subscreens/pause_sprites_extra.asm
 
 print "End of free space (83FFFF): ", pc

--- a/Code/bank_84.asm
+++ b/Code/bank_84.asm
@@ -63,11 +63,11 @@ org $82E126
 !Kill 		= $86BC
 
 ; --- Macros for door types ---
-macro %play_3(sound)
+macro play_3(sound)
 	dw $8C19 : db <sound>
 endmacro
 
-macro %open(speed, f1, f2, f3, clear)
+macro open(speed, f1, f2, f3, clear)
    %play_3($07)
 	dw <speed>, <f1>
 	dw <speed>, <f2>
@@ -76,7 +76,7 @@ macro %open(speed, f1, f2, f3, clear)
 	dw !Kill
 endmacro
 
-macro %close(wait, speed, f1, f2, f3, clear)
+macro close(wait, speed, f1, f2, f3, clear)
 	dw <wait>, <clear>
 	dw <speed>, <f1>
    %play_3($08)
@@ -84,7 +84,7 @@ macro %close(wait, speed, f1, f2, f3, clear)
 	dw <speed>, <f3>
 endmacro
 
-macro %flash(speed, f1, f2)
+macro flash(speed, f1, f2)
 	rep 3 : dw <speed>, <f1>, <speed>+1, <f2>
 	skip 4
 endmacro
@@ -92,19 +92,19 @@ endmacro
 org $84BE59
 ; ::: Regular door animations :::
 Grey_door:
-incsrc Code/data/plm/grey_door.asm
+incsrc data/plm/grey_door.asm
 
 Yellow_door:
-incsrc Code/data/plm/yellow_door.asm
+incsrc data/plm/yellow_door.asm
 
 Green_door:
-incsrc Code/data/plm/green_door.asm
+incsrc data/plm/green_door.asm
 
 Red_door:
-incsrc Code/data/plm/red_door.asm
+incsrc data/plm/red_door.asm
 
 Blue_door:
-incsrc Code/data/plm/blue_door.asm
+incsrc data/plm/blue_door.asm
 
 org $84BA4C
 ; ::: Bomb Torizo door :::
@@ -192,8 +192,8 @@ org $84BA9B
 
 ; this imports a list of defines for all the sound indexes, along with comments that explain each one
 ; and then all the changes to the plm sounds
-incsrc Code/data/plm/item_sound_arguments.asm
-incsrc Code/data/plm/item_sounds.asm
+incsrc data/plm/item_sound_arguments.asm
+incsrc data/plm/item_sounds.asm
 
 org $84EFD4
 ; free space in bank 84
@@ -217,10 +217,10 @@ print "--- End of PLM header list ---\n"
 ; :::																   :::
 
 ; --- Kejardon ---
-incsrc Plm/Disappearing_block/Disappearing_block.asm
+incsrc ../Plm/Disappearing_block/Disappearing_block.asm
 
 ; --- Quote58 (inspired by messanger patch by JAM) ---
-incsrc Plm/Messenger/Messenger.asm
+incsrc ../Plm/Messenger/Messenger.asm
 
 
 ; :::																					 :::
@@ -612,27 +612,27 @@ Collect:
 
 .speed
 	JSR $88F3								;finish the normal routine to set the equipment bit
-	LDA !C_H_Magic+!C_H_Spark : JSL Hud_init_specific		;and then refresh the hud to make sure the speed metre will show up
+	LDA !C_H_Magic+!C_H_Spark_dup : JSL Hud_init_specific		;and then refresh the hud to make sure the speed metre will show up
 	RTS
 
 ; these ammo routines could be combined, especially if you don't include the hud init stuff
 ; but it's not worth the effort right now since PB also called different message boxes
 .missile
-   %inc(!W_Missiles_max, '$0000,y')
-   %inc(!W_Missiles, '$0000,y')
-	LDA !C_H_Select+!C_H_Missiles : JSL Hud_init_specific
+   %inc(!W_Missiles_max, "$0000,y")
+   %inc(!W_Missiles, "$0000,y")
+	LDA !C_H_Select+!C_H_Missiles_dup : JSL Hud_init_specific
 	LDA #$0002 : BRA ++
 
 .super
-   %inc(!W_Supers_max, '$0000,y')
-   %inc(!W_Supers, '$0000,y')
-	LDA !C_H_Select+!C_H_Supers : JSL Hud_init_specific
+   %inc(!W_Supers_max, "$0000,y")
+   %inc(!W_Supers, "$0000,y")
+	LDA !C_H_Select+!C_H_Supers_dup : JSL Hud_init_specific
 	LDA #$0003 : BRA ++
 
 .power
-   %inc(!W_Powers_max, '$0000,y')
-   %inc(!W_Powers, '$0000,y')
-	LDA !C_H_Select+!C_H_Powers : JSL Hud_init_specific
+   %inc(!W_Powers_max, "$0000,y")
+   %inc(!W_Powers, "$0000,y")
+	LDA !C_H_Select+!C_H_Powers_dup : JSL Hud_init_specific
 	LDA #$0004 : BRA ++
 
 .reserve_tank

--- a/Code/bank_85.asm
+++ b/Code/bank_85.asm
@@ -1,19 +1,19 @@
 lorom
 
-macro %text_purple()
-	table Code/data/message_boxes/text_purple.txt
+macro text_purple()
+	table data/message_boxes/text_purple.txt
 endmacro
 
-macro %text_yellow()
-	table Code/data/message_boxes/text_yellow.txt
+macro text_yellow()
+	table data/message_boxes/text_yellow.txt
 endmacro
 
-macro %text_blue()
-	table Code/data/message_boxes/text_blue.txt
+macro text_blue()
+	table data/message_boxes/text_blue.txt
 endmacro
 
-macro %text_green()
-	table Code/data/message_boxes/text_green.txt
+macro text_green()
+	table data/message_boxes/text_green.txt
 endmacro
 
 org $858080
@@ -557,8 +557,8 @@ Message_box:
 	REP #$30
 	LDA !W_Pressed : BEQ -				;if no input, check again
 	BIT !C_B_A : BNE ++					;if input is confirmation, end the box
-	BIT !C_B_left+!C_B_up : BNE .handle_options_left
-	BIT !C_B_right+!C_B_down : BEQ -	;if input is not left/right, check again
+	BIT !C_B_left+!C_B_up_dup : BNE .handle_options_left
+	BIT !C_B_right+!C_B_down_dup : BEQ -	;if input is not left/right, check again
 
 .handle_options_right
 	LDA !W_MSG_return : INC : CMP !NumOptions : BEQ + : BMI +
@@ -755,7 +755,7 @@ Message_box_data:
 
 ; ::: headers :::
 	; --- vanilla headers ---
-	incsrc Code/data/message_boxes/vanilla_headers.asm
+	incsrc data/message_boxes/vanilla_headers.asm
 	; --- extra misc headers ---
 	dw $0000, .short, .dash_ball					;1D
 	; --- end of headers ---
@@ -763,7 +763,7 @@ Message_box_data:
 
 ; ::: data :::
 	; --- vanilla data ---
-	incsrc Code/data/message_boxes/vanilla_data.asm
+	incsrc data/message_boxes/vanilla_data.asm
 	; --- extra misc data ---
 .dash_ball
    %text_purple()

--- a/Code/bank_86.asm
+++ b/Code/bank_86.asm
@@ -84,8 +84,8 @@ Charge_attract:							;[X = projectile index]
 	LDA !C_O_Charge_attract : JSL Check_option_bit : BCC .end
 	LDA !W_Charge : CMP !C_Full_charge : BMI .end
 	
-   %sub('!ER_proj_Xpos,x', !W_X_pos, $12)
-   %sub('!ER_proj_Ypos,x', !W_Y_pos, $14)
+   %sub("!ER_proj_Xpos,x", !W_X_pos, $12)
+   %sub("!ER_proj_Ypos,x", !W_Y_pos, $14)
 	JSL !Angle_calc : STA !Angle		;get angle between the projectile and samus
 	LDA !W_Charge : CMP !C_Full_charge+1 : BPL +
 	LDA !W_Bomb_charge : BRA ++
@@ -106,8 +106,8 @@ Charge_attract:							;[X = projectile index]
 	LDA !Angle : JSL !Cosine			;get the y length (number of pixels to move vertically)
 	LDA !W_Trig_result : STA !NewY
 
-   %inc('!ER_proj_Xpos,x', !NewX)		;move the projectile towards samus
-   %inc('!ER_proj_Ypos,x', !NewY)
+   %inc("!ER_proj_Xpos,x", !NewX)		;move the projectile towards samus
+   %inc("!ER_proj_Ypos,x", !NewY)
 	
 .end
 	DEC $1B23,x

--- a/Code/bank_87.asm
+++ b/Code/bank_87.asm
@@ -18,7 +18,7 @@ org $87DF40
 ; --- Quote58 (everything here) ---
 ; ::: Reference for subscreen code :::
 ; -----------------------------------
-table Code/data/subscreens/text_subscreen.txt ;the position of letter has changed, so this is the new table
+table data/subscreens/text_subscreen.txt ;the position of letter has changed, so this is the new table
 !Size 	   = $00						;often used to store the size of a given tilemap, especially when drawing the tilemap
 !TilePal   = $18						;often used to store the palette index
 ; -----------------------------------
@@ -252,7 +252,7 @@ Equip_screen:
 	LDA !W_Reserves_type : DEC : JSR Pause_draw_cycler		;reserves_type is 0 if no reserves, and 1/2 if there are
 	
 	LDA #$0000+!C_Reserves_total : STA !Size
-	LDX !TanksX : LDY.w #$0007-!C_Reserves_total*2+#Item_tilemaps_shells
+	LDX !TanksX : LDY.w #$0007-!C_Reserves_total*2+Item_tilemaps_shells
 	JSR Pause_draw_tiles
 	
 	LDA !W_Reserves : %divide_alt(#$64) : STA !FTanks
@@ -322,7 +322,7 @@ Equip_screen_update_pal:
 	LDA !W_Beams_equip : AND #$0FFF
 	ASL A : TAY
    %pea(90)
-	LDA Beam_palette_pointers,y : TAY
+	LDA.w Beam_palette_pointers,y : TAY
 	LDA $0004,y : STA $7EC0F2
 	LDA $0006,y : STA $7EC0FC
 	LDA $0008,y : STA $7EC0FE
@@ -438,7 +438,7 @@ Equip_screen_update_samus_model:
 
 ; this contains all the backend code that handles the list objects
 ; these are all referenced by Pause_ and a list of the routines with descriptions can be found at the top of this file
-incsrc Code/data/subscreens/list_object_code.asm
+incsrc data/subscreens/list_object_code.asm
 
 
 ; --- Quote58 ---
@@ -492,6 +492,6 @@ Boots_list:	   %list($0202, $07, $3CAA, $CB93, $3F1F, $16)
 
 ; ::: Tilemaps for list options and other stuff :::
 Item_tilemaps:
-incsrc Code/data/subscreens/equip_screen/equip_list_tilemaps.asm
+incsrc data/subscreens/equip_screen/equip_list_tilemaps.asm
 
 print "End of free space (87FFFF): ",pc

--- a/Code/bank_8A.asm
+++ b/Code/bank_8A.asm
@@ -8,7 +8,7 @@ lorom
 ; so if space in 8A is ever needed, there's a shit ton of it here if you rewrite the FX loading routine to use patterns instead of full tilemaps
 
 ; if you want to change how the tilemaps look through smile, just remember the tile numbers have changed, so it'll be a little more difficult to do so...
-incsrc Code/data/misc/FX_tilemaps.asm
+incsrc data/misc/FX_tilemaps.asm
 
 org $8AE980
 ; free space in bank $8A

--- a/Code/bank_8B.asm
+++ b/Code/bank_8B.asm
@@ -32,7 +32,7 @@ End_percent_calc:
 	LDA !Tenths       : JSR .draw_digit : INX #2
 	LDA !Hundredths   : JSR .draw_digit : INX #2
 	LDA !Percent      : STA $7E0000,x
-	LDA !Percent+#$10 : STA $7E0040,x
+	LDA !Percent+$10  : STA $7E0040,x
 
    !plxy
    !plb

--- a/Code/bank_91.asm
+++ b/Code/bank_91.asm
@@ -282,7 +282,7 @@ Morph_flash_trigger:
 	LDA !W_X_pos : SEC : SBC #$0004
 	JSR .check_if_air : BNE .end
 	
-	LDA !C_Flash_amount : STA !W_Morph_flash ;activate morph flash by resetting the palette index
+	LDA.w !C_Flash_amount : STA !W_Morph_flash ;activate morph flash by resetting the palette index
 	;JSL Play_morph_sound
 	
 .end

--- a/Code/bank_93.asm
+++ b/Code/bank_93.asm
@@ -107,13 +107,13 @@ Beam:
 .plasma_ice		 		: %proj_dir("plasma",	  	  	  $00C8)
 .plasma_wave_ice		: %proj_dir("plasma_wave",	  	  $012C)
 
-incsrc Code/data/projectiles/vanilla/beams/power.asm
-incsrc Code/data/projectiles/vanilla/beams/wave.asm
-incsrc Code/data/projectiles/vanilla/beams/ice.asm
-incsrc Code/data/projectiles/vanilla/beams/spazer.asm
-incsrc Code/data/projectiles/vanilla/beams/spazer_wave.asm
-incsrc Code/data/projectiles/vanilla/beams/plasma.asm
-incsrc Code/data/projectiles/vanilla/beams/plasma_wave.asm
+incsrc data/projectiles/vanilla/beams/power.asm
+incsrc data/projectiles/vanilla/beams/wave.asm
+incsrc data/projectiles/vanilla/beams/ice.asm
+incsrc data/projectiles/vanilla/beams/spazer.asm
+incsrc data/projectiles/vanilla/beams/spazer_wave.asm
+incsrc data/projectiles/vanilla/beams/plasma.asm
+incsrc data/projectiles/vanilla/beams/plasma_wave.asm
 
 ; ::: Charged Beams :::
 Beam_c:
@@ -130,13 +130,13 @@ Beam_c:
 .plasma_ice		 		: %proj_dir("plasma",      		  $0258)
 .plasma_wave_ice 		: %proj_dir("plasma_wave", 		  $0384)
 
-incsrc Code/data/projectiles/vanilla/beams/charged_power.asm
-incsrc Code/data/projectiles/vanilla/beams/charged_wave.asm
-incsrc Code/data/projectiles/vanilla/beams/charged_ice.asm
-incsrc Code/data/projectiles/vanilla/beams/charged_spazer.asm
-incsrc Code/data/projectiles/vanilla/beams/charged_spazer_wave.asm
-incsrc Code/data/projectiles/vanilla/beams/charged_plasma.asm
-incsrc Code/data/projectiles/vanilla/beams/charged_plasma_wave.asm
+incsrc data/projectiles/vanilla/beams/charged_power.asm
+incsrc data/projectiles/vanilla/beams/charged_wave.asm
+incsrc data/projectiles/vanilla/beams/charged_ice.asm
+incsrc data/projectiles/vanilla/beams/charged_spazer.asm
+incsrc data/projectiles/vanilla/beams/charged_spazer_wave.asm
+incsrc data/projectiles/vanilla/beams/charged_plasma.asm
+incsrc data/projectiles/vanilla/beams/charged_plasma_wave.asm
 
 ; ::: Missile/Super/Power + Spark echo :::
 Misc:
@@ -165,14 +165,14 @@ Misc:
 	dw $0002,Projectile_no_sprite,$2020,$0003
 	dw $8239,.spark_echo
 
-incsrc Code/data/projectiles/vanilla/missile.asm
-incsrc Code/data/projectiles/vanilla/super_missile.asm
-incsrc Code/data/projectiles/vanilla/bomb.asm
-incsrc Code/data/projectiles/vanilla/power_bomb.asm
-incsrc Code/data/projectiles/vanilla/beam_explosion.asm
-incsrc Code/data/projectiles/vanilla/missile_explosion.asm
-incsrc Code/data/projectiles/vanilla/super_missile_explosion.asm
-incsrc Code/data/projectiles/vanilla/bomb_explosion.asm
+incsrc data/projectiles/vanilla/missile.asm
+incsrc data/projectiles/vanilla/super_missile.asm
+incsrc data/projectiles/vanilla/bomb.asm
+incsrc data/projectiles/vanilla/power_bomb.asm
+incsrc data/projectiles/vanilla/beam_explosion.asm
+incsrc data/projectiles/vanilla/missile_explosion.asm
+incsrc data/projectiles/vanilla/super_missile_explosion.asm
+incsrc data/projectiles/vanilla/bomb_explosion.asm
 
 ; ::: Special Beam Attacks :::
 SBA:
@@ -228,8 +228,8 @@ Flare:
 	dw .charge_s00, .charge_s02
 	dw .charge_s00, .charge_s02
 
-incsrc Code/data/projectiles/vanilla/charge_flare.asm
-incsrc Code/data/projectiles/vanilla/charge_sparks.asm
+incsrc data/projectiles/vanilla/charge_flare.asm
+incsrc data/projectiles/vanilla/charge_sparks.asm
 
 ; ::: Free space for anything else until the end of the bank :::
 ; --- Black Falcon (modified by Quote58) ---

--- a/Code/bank_94.asm
+++ b/Code/bank_94.asm
@@ -20,7 +20,7 @@ org $94935B : LDA.w BTS_bomb_table_collisions,x
 org $94933C : LDA.w BTS_bomb_table_collisions,x
 
 ; gotta import some labels so the tables don't look all fucked up
-incsrc Code/data/plm/bts_plm_labels.asm
+incsrc data/plm/bts_plm_labels.asm
 
 org $949139
 BTS_crumble_table:

--- a/Code/bank_A0.asm
+++ b/Code/bank_A0.asm
@@ -184,10 +184,10 @@ Backflip:
 !DecayOne 	   = #$0006					;How many frames until 1st vertical momentum slowdown
 !DecayTwo 	   = #$0012					;How many frames until 2nd vertical momentum slowdown
 !DecayThree    = #$0025					;How many frames until 3rd vertical momentum slowdown / after falling
-!StartSpeed	   = #$0005					;How many pixels to boost up at the start
-!LiftSpeed 	   = #$0004					;How many pixels to boost up during damage boost
-!DecaySpeedOne = #$0002					;How many pixels to boost up during damage boost after 1st decay time
-!DecaySpeedTwo = #$0001					;How many pixels to boost up during damage boost after 2nd decay time
+!StartSpeed	   = $0005					;How many pixels to boost up at the start
+!LiftSpeed 	   = $0004					;How many pixels to boost up during damage boost
+!DecaySpeedOne = $0002					;How many pixels to boost up during damage boost after 1st decay time
+!DecaySpeedTwo = $0001					;How many pixels to boost up during damage boost after 2nd decay time
 
 ;*** add check for being under liquid and distinguish between water/lava/acid ***
 

--- a/Code/data/hud/hud_methods.asm
+++ b/Code/data/hud/hud_methods.asm
@@ -179,6 +179,7 @@
 
 .draw_magic_metre
 !Len = #$07
+!Len_dup = $07
 !Total = $12
 !DivA = $12
 !DivB = $14
@@ -192,7 +193,7 @@
 	LDA !DivA : %multiply(!Len)
    %divide_alt(!DivB) : STA !Total
 	LDX !Index
-	LDY #$0000+!Len-1
+	LDY #$0000+!Len_dup-1
 	-
 	LDA !Total : BMI +
 	LDA #$0000 : BRA ++

--- a/Code/data/hud/module_data.asm
+++ b/Code/data/hud/module_data.asm
@@ -63,7 +63,7 @@
 
 .magic_display
 	dw Hud_condition_speed, Hud_tilemaps_magic_display
-	dw !C_H_Magic+!C_H_Spark, Hud_method_draw_magic_display
+	dw !C_H_Magic+!C_H_Spark_dup, Hud_method_draw_magic_display
 
 .missiles_counter
 	dw Hud_condition_missiles, Hud_tilemaps_empty_3_digit_counter

--- a/main.asm
+++ b/main.asm
@@ -179,7 +179,9 @@ lorom
 
 ;the bit value of a given hardware button, used to check against input registers and their ram mirrors
 !C_B_up				= #$0800
+!C_B_up_dup			= $0800
 !C_B_down			= #$0400
+!C_B_down_dup		= $0400
 !C_B_left			= #$0200
 !C_B_right			= #$0100
 !C_B_X				= #$0040
@@ -212,14 +214,18 @@ lorom
 ;the bit value of a given hud modual in the modual update array
 !C_H_Health			= #$0001
 !C_H_Missiles		= #$0002
+!C_H_Missiles_dup	= $0002
 !C_H_Supers			= #$0004
+!C_H_Supers_dup		= $0004
 !C_H_Powers			= #$0008
+!C_H_Powers_dup		= $0008
 !C_H_Select			= #$0010
 !C_H_Input			= #$0020
 !C_H_Minimap		= #$0040
 !C_H_Charge			= #$0080
 !C_H_Magic			= #$0100
 !C_H_Spark			= #$0200
+!C_H_Spark_dup		= $0200
 !C_H_Reserves		= #$0400
 
 ;the bit value of options are single bytes because they are stored in the extra event bit array and 


### PR DESCRIPTION
I was looking for examples of compatibility problems with xkas patches in asar and Benox50 pointed me here. After finding all the missing graphics (by temporarily reverting the "cleanup" commit that deleted them), I cleared up all of the errors asar mentioned.

You might not like the way I handled certain things, like creating _dup defines for adding two numbers that start with #. I didn't want to risk them being used somewhere else and messing something up. Feel free to make suggestions or changes. It does break xkas compatibility to do this, mostly because of the way paths are referenced between the two. Won't bother me if you'd rather not make that sacrifice.